### PR TITLE
Added an alteration step for normal objects.

### DIFF
--- a/NTestDataBuilder.Tests/BuildTests.cs
+++ b/NTestDataBuilder.Tests/BuildTests.cs
@@ -30,5 +30,23 @@ namespace NTestDataBuilder.Tests
             Assert.That(customer.LastName, Is.EqualTo("Kocaj"));
             Assert.That(customer.YearJoined, Is.EqualTo(2010));
         }
+
+        [Test]
+        public void GivenBuilderWithAlterations_WhenCallingBuild_ThenReturnAnAlteredObject()
+        {
+            bool altered = false;
+            var builder = new CustomerBuilder()
+                .WithFirstName("Matt")
+                .WithLastName("Kocaj")
+                .WhoJoinedIn(2010)
+                .WithAlteration(x => { altered = true; return x; });
+
+            var customer = builder.Build();
+
+            Assert.That(customer.FirstName, Is.EqualTo("Matt"));
+            Assert.That(customer.LastName, Is.EqualTo("Kocaj"));
+            Assert.That(customer.YearJoined, Is.EqualTo(2010));
+            Assert.IsTrue(altered);
+        }
     }
 }

--- a/NTestDataBuilder.Tests/Builders/CustomerBuilder.cs
+++ b/NTestDataBuilder.Tests/Builders/CustomerBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using FizzWare.NBuilder;
 using NTestDataBuilder.Tests.Entities;
+using System;
 
 namespace NTestDataBuilder.Tests.Builders
 {
@@ -44,6 +45,12 @@ namespace NTestDataBuilder.Tests.Builders
             return this;
         }
 
+        public CustomerBuilder WithAlteration(Func<Customer, Customer> alteration)
+        {
+            OnAlter += (c) => alteration(c);
+            return this;
+        }
+
         protected override Customer BuildObject()
         {
             return new Customer(
@@ -52,5 +59,10 @@ namespace NTestDataBuilder.Tests.Builders
                 Get(x => x.YearJoined)
             );
         }
+
+        protected override Customer Alter(Customer c) { return OnAlter == null ? c :  OnAlter(c); }
+
+        public delegate Customer AlterEventDelegate(Customer c);
+        public event AlterEventDelegate OnAlter;
     }
 }

--- a/NTestDataBuilder/TestDataBuilder.cs
+++ b/NTestDataBuilder/TestDataBuilder.cs
@@ -43,7 +43,7 @@ namespace NTestDataBuilder
                 return proxy;
             }
 
-            return BuildObject();
+            return Alter(BuildObject());
         }
 
         /// <summary>
@@ -68,6 +68,13 @@ namespace NTestDataBuilder
         /// </summary>
         /// <param name="proxy">The proxy object</param>
         protected virtual void AlterProxy(TObject proxy) {}
+
+        /// <summary>
+        /// Alter the object just after it has been built and before it's returned from .Build().
+        /// This allows you to write base-class builders which encapsulate common logic.
+        /// </summary>
+        /// <param name="obj"></param>
+        protected virtual TObject Alter(TObject obj) { return obj; }
         
         /// <summary>
         /// Records the given value for the given property from <see cref="TObject"/>.


### PR DESCRIPTION
Similar to how Proxy objects have an additional Alter step, normal objects now include an Alter method.

As a specific motivating example, at work, everything stored to the database derives from Persistable.  So, I would like to provide a base PersistableBuilder class, which has a .PersistedTo(IUnitOfWork) method for every derived builder.  However, I have no access to the objects produced in the child classes without basically this same solution.  It seemed like it would be useful to the rest of the project, so I included it at the root.

One thing that I was unsure on was whether Alter should be void return type, as with Proxy, or type T->T.  I chose to go with T->T, as it allows you to return entirely different objects if you really want, but I didn't have a use for that and you might want to make that simplification to the interface before merging it in.