### PR TITLE
Fluent set

### DIFF
--- a/NTestDataBuilder.Tests/BuildTests.cs
+++ b/NTestDataBuilder.Tests/BuildTests.cs
@@ -30,5 +30,19 @@ namespace NTestDataBuilder.Tests
             Assert.That(customer.LastName, Is.EqualTo("Kocaj"));
             Assert.That(customer.YearJoined, Is.EqualTo(2010));
         }
+
+        [Test]
+        public void GivenBuilder_WhenCallingSet_ShouldOverrideValues()
+        {
+            var builder = new CustomerBuilder()
+                .Set(x => x.FirstName, "Pi")
+                .Set(x => x.LastName, "Lanningham")
+                .Set(x => x.YearJoined, 2014);
+
+            var customer = builder.Build();
+            Assert.That(customer.FirstName, Is.EqualTo("Pi"));
+            Assert.That(customer.LastName, Is.EqualTo("Lanningham"));
+            Assert.That(customer.YearJoined, Is.EqualTo(2014));
+        }
     }
 }

--- a/NTestDataBuilder/TestDataBuilder.cs
+++ b/NTestDataBuilder/TestDataBuilder.cs
@@ -78,7 +78,7 @@ namespace NTestDataBuilder
         public TBuilder Set<TValue>(Expression<Func<TObject, TValue>> property, TValue value)
         {
             _properties[GetPropertyName(property)] = value;
-            return (TBuilder)this;
+            return this as TBuilder;
         }
 
         /// <summary>


### PR DESCRIPTION
At work we were writing a lot of annoying boilerplate, and this seemed like an obvious simplification to the interface.

I'm not sure if you avoided it due to your own philosophical opinions on the matter (providing methods for everything make the test cases read a lot more like sentences, maybe that is what you were going for), but I like this a lot better for customization that doesn't have to enforce constraints on the parameters.

With this, at work, we end up writing only one or two methods for each builder, those which have important constraints to enforce (for example, the "Term" field being of the format "FALL14" and not just any arbitrary string) or metadata to generate (for example, .WithSuitemates(4) generating 4 random suitemates for you), and any raw property setters are done via a simple call to Set.

In the future, you might want to allow a Builder to define which fields CAN'T be modified, so that they're forced to go through the custom method, but we don't currently have a need for that at work.  If you want me to write that code, however, let me know!
