### PR TITLE
Adds a Set overload which takes a lambda factory method

### DIFF
--- a/CONTRIBUTOR_GUIDELINES.md
+++ b/CONTRIBUTOR_GUIDELINES.md
@@ -1,0 +1,11 @@
+Contributor Guidelines
+======================
+
+Hi! Thank you for your interest in contributing to this open source library!
+We ask that you follow the following style guidelines when submitting pull
+requests, to keep the code consistent and maintainable.
+
+ - Do not put an if clause and it's statement on the same line: separate them
+   with a new-line and indent accordingly.
+
+(This file will be expanded as more guidelines are established by the maintainer)

--- a/TestStack.Dossier.Tests/BuildTests.cs
+++ b/TestStack.Dossier.Tests/BuildTests.cs
@@ -1,4 +1,5 @@
-﻿using Shouldly;
+﻿using System.Collections.Generic;
+using Shouldly;
 using TestStack.Dossier.Tests.TestHelpers.Builders;
 using TestStack.Dossier.Tests.TestHelpers.Objects.Entities;
 using Xunit;
@@ -45,6 +46,32 @@ namespace TestStack.Dossier.Tests
             customer.FirstName.ShouldBe("Pi");
             customer.LastName.ShouldBe("Lanningham");
             customer.YearJoined.ShouldBe(2014);
+        }
+
+        [Fact]
+        public void GivenBuilder_WhenCallingSetWithLambda_ShouldInvokeEachTime()
+        {
+            int counter = 2014;
+            var builder = new CustomerBuilder()
+                .Set(x => x.FirstName, "Pi")
+                .Set(x => x.LastName, "Lanningham")
+                .Set(x => x.YearJoined, () => counter++);
+
+            var customerA = builder.Build();
+            var customerB = builder.Build();
+
+            customerA.YearJoined.ShouldBe(2014);
+            customerB.YearJoined.ShouldBe(2015);
+
+            List<Customer> customerList = CustomerBuilder.CreateListOfSize(10)
+                                            .All()
+                                                .Set(x => x.YearJoined, () => counter++);
+            int newCounter = 2016;
+            foreach (var c in customerList)
+            {
+                c.YearJoined.ShouldBe(newCounter++);
+            }
+
         }
 
         [Fact]

--- a/TestStack.Dossier.Tests/ProxyBuilderTests.cs
+++ b/TestStack.Dossier.Tests/ProxyBuilderTests.cs
@@ -12,7 +12,7 @@ namespace TestStack.Dossier.Tests
         [Fact]
         public void GivenClassToProxyWithNoProperties_WhenBuildingProxy_ReturnAClassWithNoReturnsValuesSet()
         {
-            var proxyBuilder = new ProxyBuilder<Customer>(new Dictionary<string, object>());
+            var proxyBuilder = new ProxyBuilder<Customer>(new Dictionary<string, Func<object>>());
 
             var proxy = proxyBuilder.Build();
 
@@ -24,7 +24,7 @@ namespace TestStack.Dossier.Tests
         [Fact]
         public void GivenClassToProxyWithNoProperties_WhenBuildingProxy_ReturnAnNSubstituteProxyOfThatClass()
         {
-            var proxyBuilder = new ProxyBuilder<Customer>(new Dictionary<string, object>());
+            var proxyBuilder = new ProxyBuilder<Customer>(new Dictionary<string, Func<object>>());
 
             var proxy = proxyBuilder.Build();
 
@@ -32,13 +32,14 @@ namespace TestStack.Dossier.Tests
         }
 
         [Fact]
-        public void GivenClassToProxyWithSinglePropertyValue_WhenBuildingProxy_ReturnAClassWithReturnValueSet()
+        public void GivenClassToProxyWithSinglePropertyValue_WhenBuildingProxy_ReturnAClassWithReturnValueSetFromFunction()
         {
-            var proxyBuilder = new ProxyBuilder<Customer>(new Dictionary<string, object> {{"FirstName", "FirstName"}});
+            int nonce = new Random().Next(0, 100);
+            var proxyBuilder = new ProxyBuilder<Customer>(new Dictionary<string, Func<object>> {{"FirstName", () => "FirstName" + nonce}});
 
             var proxy = proxyBuilder.Build();
 
-            proxy.FirstName.ShouldBe("FirstName");
+            proxy.FirstName.ShouldBe("FirstName" + nonce);
             proxy.LastName.ShouldBe(string.Empty);
             proxy.YearJoined.ShouldBe(0);
         }
@@ -46,11 +47,11 @@ namespace TestStack.Dossier.Tests
         [Fact]
         public void GivenClassToProxyWithMultiplePropertyValues_WhenBuildingProxy_ReturnAClassWithReturnValueSet()
         {
-            var proxyBuilder = new ProxyBuilder<Customer>(new Dictionary<string, object>
+            var proxyBuilder = new ProxyBuilder<Customer>(new Dictionary<string, Func<object>>
                 {
-                    { "FirstName", "FirstName" },
-                    { "LastName", "LastName" },
-                    { "YearJoined", 1 },
+                    { "FirstName", () => "FirstName" },
+                    { "LastName", () => "LastName" },
+                    { "YearJoined", () => 1 },
                 }
             );
 
@@ -64,10 +65,10 @@ namespace TestStack.Dossier.Tests
         [Fact]
         public void GivenClassWithSomeVirtualProperties_WhenBuildingProxy_ThenOnlyVirtualMembersAreProxied()
         {
-            var proxyBuilder = new ProxyBuilder<Company>(new Dictionary<string, object>()
+            var proxyBuilder = new ProxyBuilder<Company>(new Dictionary<string, Func<object>>()
             {
-                {"Name", "Vandelay Industries"},
-                {"EmployeeCount", 100}
+                {"Name", () => "Vandelay Industries"},
+                {"EmployeeCount", () => 100}
             });
 
             var proxy = proxyBuilder.Build();

--- a/TestStack.Dossier/ProxyBuilder.cs
+++ b/TestStack.Dossier/ProxyBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NSubstitute;
@@ -11,13 +12,13 @@ namespace TestStack.Dossier
     /// <typeparam name="T">The type being proxied</typeparam>
     public class ProxyBuilder<T> where T : class
     {
-        private readonly Dictionary<string, object> _properties;
+        private readonly Dictionary<string, Func<object>> _properties;
 
         /// <summary>
         /// Create a proxy builder to proxy the given property values for the type {T}.
         /// </summary>
         /// <param name="properties"></param>
-        public ProxyBuilder(Dictionary<string, object> properties)
+        public ProxyBuilder(Dictionary<string, Func<object>> properties)
         {
             _properties = properties;
         }
@@ -33,7 +34,7 @@ namespace TestStack.Dossier
             foreach (var property in properties.Where(property => _properties.ContainsKey(property.Name)))
             {
                 if (property.GetGetMethod().IsVirtual)
-                    property.GetValue(proxy, null).Returns(_properties[property.Name]);
+                    property.GetValue(proxy, null).Returns(_properties[property.Name]());
             }
 
             return proxy;

--- a/TestStack.Dossier/TestDataBuilder.cs
+++ b/TestStack.Dossier/TestDataBuilder.cs
@@ -127,6 +127,7 @@ namespace TestStack.Dossier
         /// <typeparam name="TValue">The type of the property</typeparam>
         /// <param name="property">A lambda expression specifying the property to record a value for</param>
         /// <param name="factory">A method which produces instances of {TValue} for the property.</param>
+        /// <returns>The builder so that other method calls can be chained</returns>
         public virtual TBuilder Set<TValue>(Expression<Func<TObject, TValue>> property, Func<TValue> factory)
         {
             _properties[Reflector.GetPropertyNameFor(property)] = () => factory() as object;

--- a/TestStack.Dossier/TestDataBuilder.cs
+++ b/TestStack.Dossier/TestDataBuilder.cs
@@ -156,7 +156,8 @@ namespace TestStack.Dossier
         public object Get(Type type, string propertyName)
         {
             Func<object> factory;
-            if (_properties.TryGetValue(propertyName, out factory)) return factory();
+            if (_properties.TryGetValue(propertyName, out factory))
+                return factory();
 
             return Any.Get(type, propertyName);
         } 

--- a/TestStack.Dossier/TestDataBuilder.cs
+++ b/TestStack.Dossier/TestDataBuilder.cs
@@ -16,6 +16,7 @@ namespace TestStack.Dossier
         where TBuilder : TestDataBuilder<TObject, TBuilder>, new()
     {
         private readonly Dictionary<string, object> _properties = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
+        private readonly Dictionary<string, Func<object>> _propFactories = new Dictionary<string, Func<object>>();
         private ProxyBuilder<TObject> _proxyBuilder;
 
         /// <summary>
@@ -107,16 +108,29 @@ namespace TestStack.Dossier
         /// </summary>
         /// <param name="proxy">The proxy object</param>
         protected virtual void AlterProxy(TObject proxy) {}
-        
+
         /// <summary>
         /// Records the given value for the given property from {TObject} and returns the builder to allow chaining.
         /// </summary>
         /// <typeparam name="TValue">The type of the property</typeparam>
         /// <param name="property">A lambda expression specifying the property to record a value for</param>
-        /// <param name="value">The builder so that other method calls can be chained</param>
+        /// <param name="value">The value to set the property to</param>
+        /// <returns>The builder so that other method calls can be chained</returns>
         public virtual TBuilder Set<TValue>(Expression<Func<TObject, TValue>> property, TValue value)
         {
             _properties[Reflector.GetPropertyNameFor(property)] = value;
+            return this as TBuilder;
+        }
+
+        /// <summary>
+        /// Records a given value provider for the given property from {TObject} and returns the builder to allow chaining.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property</typeparam>
+        /// <param name="property">A lambda expression specifying the property to record a value for</param>
+        /// <param name="factory">A method which produces instances of {TValue} for the property.</param>
+        public virtual TBuilder Set<TValue>(Expression<Func<TObject, TValue>> property, Func<TValue> factory)
+        {
+            _propFactories[Reflector.GetPropertyNameFor(property)] = () => factory() as object;
             return this as TBuilder;
         }
 
@@ -129,10 +143,7 @@ namespace TestStack.Dossier
         /// <returns>The recorded value of the property or an anonymous value for it</returns>
         public TValue Get<TValue>(Expression<Func<TObject, TValue>> property)
         {
-            if (!Has(property))
-                return Any.Get(property);
-
-            return (TValue)_properties[Reflector.GetPropertyNameFor(property)];
+            return (TValue)Get(typeof (TValue), Reflector.GetPropertyNameFor(property));
         }
 
         /// <summary>
@@ -144,9 +155,13 @@ namespace TestStack.Dossier
         /// <returns></returns>
         public object Get(Type type, string propertyName)
         {
-            if (!Has(propertyName))
-                return Any.Get(type, propertyName);
-            return _properties[propertyName];
+            object value;
+            if (_properties.TryGetValue(propertyName, out value)) return value;
+
+            Func<object> factory;
+            if (_propFactories.TryGetValue(propertyName, out factory)) return factory();
+
+            return Any.Get(type, propertyName);
         } 
 
         /// <summary>
@@ -193,7 +208,7 @@ namespace TestStack.Dossier
         /// <returns>Whether or not there is a recorded value for the property</returns>
         protected bool Has(string propertyName)
         {
-            return _properties.ContainsKey(propertyName);
+            return _properties.ContainsKey(propertyName) || _propFactories.ContainsKey(propertyName);
         }
 
         /// <summary>


### PR DESCRIPTION
 - The specific use case for this is that we wanted to be able
   to use equivalence classes.  However, if you just use them naively,
   it would generate a single value and use it for all of the instances
   it created.
 - The lambda overload not only enables this case, but gives some power
   to constructing incrementing counters and the like.  For example,
   using a Queue to generate an ordered set of names, or other such use
   cases.